### PR TITLE
A few fixes before releasing 0.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ project(':suro-server') {
     compile 'com.sun.jersey.contribs:jersey-guice:1.11'
     compile 'com.sun.jersey:jersey-bundle:1.11'
     compile 'com.amazonaws:aws-java-sdk:1.4.7'
+    compile 'javax.servlet:servlet-api:2.5'
 
     compile 'commons-cli:commons-cli:1.2'
     

--- a/suro-core/src/main/java/com/netflix/suro/sink/DynamicPropertySinkConfigurator.java
+++ b/suro-core/src/main/java/com/netflix/suro/sink/DynamicPropertySinkConfigurator.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.netflix.config.DynamicStringProperty;
 import com.netflix.governator.annotations.Configuration;
-import com.netflix.suro.routing.DynamicPropertyRoutingMapConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +19,7 @@ import java.util.Map;
  * @author elandau
  */
 public class DynamicPropertySinkConfigurator {
-    private static final Logger log = LoggerFactory.getLogger(DynamicPropertyRoutingMapConfigurator.class);
+    private static final Logger log = LoggerFactory.getLogger(DynamicPropertySinkConfigurator.class);
 
     public static final String SINK_PROPERTY = "SuroServer.sinkConfig";
 

--- a/suro-kafka/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
+++ b/suro-kafka/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.netflix.servo.monitor.Monitors;
 import com.netflix.suro.message.Message;
 import com.netflix.suro.message.MessageContainer;
 import com.netflix.suro.queue.MemoryQueue4Sink;
@@ -93,6 +94,8 @@ public class KafkaSink extends QueuedSink implements Sink {
 
         producer = new Producer<Long, byte[]>(new ProducerConfig(props));
         KafkaMetricsReporter$.MODULE$.startReporters(new VerifiableProperties(props));
+
+        Monitors.registerObject(KafkaSink.class.getSimpleName() + "-" + clientId, this);
     }
 
     @Override

--- a/suro-server/src/main/java/com/netflix/suro/sink/ServerSinkPlugin.java
+++ b/suro-server/src/main/java/com/netflix/suro/sink/ServerSinkPlugin.java
@@ -1,7 +1,9 @@
 package com.netflix.suro.sink;
 
 import com.netflix.suro.SuroPlugin;
+import com.netflix.suro.message.Message;
 import com.netflix.suro.sink.kafka.KafkaSink;
+import com.netflix.suro.sink.kafka.SuroKeyedMessage;
 import com.netflix.suro.sink.localfile.LocalFileSink;
 import com.netflix.suro.sink.notice.LogNotice;
 import com.netflix.suro.sink.notice.NoNotice;
@@ -23,6 +25,7 @@ public class ServerSinkPlugin extends SuroPlugin {
         this.addSinkType(LocalFileSink.TYPE, LocalFileSink.class);
 
         this.addSinkType(KafkaSink.TYPE, KafkaSink.class);
+        Message.classMap.put((byte) 1, SuroKeyedMessage.class);
 
         this.addSinkType(S3FileSink.TYPE, S3FileSink.class);
         this.addSinkType(HdfsFileSink.TYPE, HdfsFileSink.class);


### PR DESCRIPTION
- servlet-api is explicitly added to suro-server dependency
- DynamicPropertySinkConfigurator logger classname fixed
- KafkaSink, registers in servo Monitors
- KafkaSink, register SuroKeyeydMessage to Message.classMap on ServerSinkPlugin, this needs to be improved for better modularity
