### PR TITLE
RemoteFileSink's pending messages should consider files

### DIFF
--- a/suro-localfile/src/main/java/com/netflix/suro/sink/localfile/LocalFileSink.java
+++ b/suro-localfile/src/main/java/com/netflix/suro/sink/localfile/LocalFileSink.java
@@ -284,12 +284,12 @@ public class LocalFileSink extends QueuedSink implements Sink {
     }
 
     /**
-     * This method calls {@link #cleanUp(String)} with outputDir
+     * This method calls {@link #cleanUp(String, boolean)} with outputDir
      *
      * @return
      */
-    public int cleanUp() {
-        return cleanUp(outputDir);
+    public int cleanUp(boolean fetchAll) {
+        return cleanUp(outputDir, fetchAll);
     }
 
     /**
@@ -301,7 +301,7 @@ public class LocalFileSink extends QueuedSink implements Sink {
      * @param dir
      * @return the number of files found in the directory
      */
-    public int cleanUp(String dir) {
+    public int cleanUp(String dir, boolean fetchAll) {
         if (!dir.endsWith("/")) {
             dir += "/";
         }
@@ -328,12 +328,15 @@ public class LocalFileSink extends QueuedSink implements Sink {
                             writer.setDone(dir + fileName, dir + doneFile);
                             notice.send(dir + doneFile);
                             ++count;
+                        } else if (fetchAll) {
+                            ++count;
                         }
                     }
                 }
             }
         } catch (Exception e) {
             log.error("Exception while on cleanUp: " + e.getMessage(), e);
+            return Integer.MAX_VALUE; // return non-zero value
         }
 
         return count;

--- a/suro-s3/src/test/java/com/netflix/suro/sink/remotefile/TestS3FileSink.java
+++ b/suro-s3/src/test/java/com/netflix/suro/sink/remotefile/TestS3FileSink.java
@@ -190,7 +190,7 @@ public class TestS3FileSink {
         File f = new File(testDir, "fileNo" + i + ".done");
         f.createNewFile();
         FileOutputStream o = new FileOutputStream(f);
-        o.write(100/*any data*/);
+        o.write("temporaryStringContents".getBytes());
         o.close();
     }
 
@@ -219,16 +219,20 @@ public class TestS3FileSink {
 
         S3FileSink sink = mapper.readValue(s3FileSink, new TypeReference<Sink>(){});
         sink.open();
+        assertEquals(sink.getNumOfPendingMessages(), 100);
         sink.uploadAll(testDir);
 
         // check every file uploaded, deleted, and notified
-        File[] files = getFiles(testDir);
-        assertEquals(files.length, 0);
         int count = 0;
         while (sink.recvNotice() != null) {
             ++count;
         }
         assertEquals(count, 100);
+
+        File[] files = getFiles(testDir);
+        assertEquals(files.length, 0);
+
+        assertEquals(sink.getNumOfPendingMessages(), 0);
     }
 
     @Test


### PR DESCRIPTION
- cleanUp with fetchAll to describe unclosed files
- RemoteFileSink.getNumOfPendingMessages() is returning the number of files not uploaded yet when the number of pending messages in LocalFileSink is 0
