### PR TITLE
Automatically creating file queue directories for Queue4client

### DIFF
--- a/suro-client/src/main/java/com/netflix/suro/client/async/Queue4Client.java
+++ b/suro-client/src/main/java/com/netflix/suro/client/async/Queue4Client.java
@@ -27,10 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/suro-client/src/test/java/com/netflix/suro/client/async/TestAsyncSuroClientWithNonExistentFilePath.java
+++ b/suro-client/src/test/java/com/netflix/suro/client/async/TestAsyncSuroClientWithNonExistentFilePath.java
@@ -31,13 +31,9 @@ import com.netflix.suro.connection.TestConnectionPool;
 import com.netflix.suro.message.Message;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Properties;
 


### PR DESCRIPTION
The current Queue4Client swallows IOException if the given file queue path does not exist. This will lead to NullPointerException later, making debugging hard. The fix is as follows: 
- IOException will be wrapped into an IllegalStateException and re-thrown
- If a given file queue path is not a directory, an IllegalStateException will be thrown
- If a given file queue path does not exists, the Queue4Client will try to create the full path. If the attempt to create the path fails, an IllegalStateException will be thrown 
