### PR TITLE
Disable ConnectionOutPool

### DIFF
--- a/suro-client/src/main/java/com/netflix/suro/ClientConfig.java
+++ b/suro-client/src/main/java/com/netflix/suro/ClientConfig.java
@@ -30,6 +30,11 @@ public class ClientConfig {
         return connectionTimeout;
     }
 
+    public static final String ENABLE_OUTPOOL = "SuroClient.enableOutPool";
+    @Configuration(ENABLE_OUTPOOL)
+    private boolean enableOutPool = false;
+    public boolean getEnableOutPool() { return enableOutPool; }
+
     public static final String CONNECTION_SWEEP_INTERVAL = "SuroClient.connectionSweepInterval";
     @Configuration(CONNECTION_SWEEP_INTERVAL)
     private int connectionSweepInterval = 3600; // second

--- a/suro-client/src/test/java/com/netflix/suro/client/async/TestAsyncSuroSender.java
+++ b/suro-client/src/test/java/com/netflix/suro/client/async/TestAsyncSuroSender.java
@@ -25,6 +25,7 @@ import com.netflix.governator.lifecycle.LifecycleManager;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.suro.ClientConfig;
 import com.netflix.suro.SuroServer4Test;
+import com.netflix.suro.connection.ConnectionPool;
 import com.netflix.suro.connection.StaticLoadBalancer;
 import com.netflix.suro.connection.TestConnectionPool;
 import org.junit.After;
@@ -164,9 +165,13 @@ public class TestAsyncSuroSender {
         for (SuroServer4Test c : servers) {
             c.cancelTryLater();
         }
+        injector.getInstance(ConnectionPool.class).populateClients();
 
         // wait until client restored
-        Thread.sleep(1000);
+        while (client.getSentMessageCount() < 600) {
+            System.out.println("sent: " + client.getSentMessageCount());
+            Thread.sleep(1000);
+        }
         client.shutdown();
         TestConnectionPool.checkMessageCount(servers, 600);
     }


### PR DESCRIPTION
Added configuration SuroClient.enableOutPool, by default false
SuroClient result status code is not OK, the server should be marked down
When OutPool is disabled, ConnectionOutPool should not be created
Unit tests fixed
