### PR TITLE
(1) update rxjava version to 0.20.1 because 0.20.x is what platform reso...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ subprojects {
     }
 
     dependencies {
+      compile 'com.netflix.rxjava:rxjava-core:0.20.1'
       compile 'com.netflix.archaius:archaius-core:0.5.11'
       compile 'com.netflix.servo:servo-core:0.4.32'
       compile 'com.netflix.governator:governator:1.2.3'

--- a/suro-kafka-producer/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
+++ b/suro-kafka-producer/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
@@ -98,7 +98,7 @@ public class KafkaSink implements Sink {
         }
 
         this.metadataWaitingQueuePolicy = new MetadataWaitingQueuePolicy(
-                metadataWaitingQueueSize <= 0 ? 10000 : metadataWaitingQueueSize,
+                metadataWaitingQueueSize <= 0 ? 1000 : metadataWaitingQueueSize,
                 blockOnMetadataQueueFull);
         this.keyTopicMap = keyTopicMap != null ? keyTopicMap : Maps.<String, String>newHashMap();
 
@@ -283,6 +283,7 @@ public class KafkaSink implements Sink {
     @Override
     public void open() {
         producer = new KafkaProducer(props);
+        // TODO: backpressure handling
         subscription = stream
                 .filter(new Func1<MessageContainer, Boolean>() {
                     @Override


### PR DESCRIPTION
...lves to via transitive dep. (2) reduce default metadata wait queue size from 10,000 to 1,000 because rxjava 0.20 default size for internal queue is 1024. our semaphore size should be smaller than 1024.