### PR TITLE
schedule sink map update in Rx io scheduler, because KafkaProducer.close...

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.29-platform
+version=0.2.30-platform

--- a/suro-core/src/test/java/com/netflix/suro/sink/TestSinkManager.java
+++ b/suro-core/src/test/java/com/netflix/suro/sink/TestSinkManager.java
@@ -94,4 +94,84 @@ public class TestSinkManager {
         Assert.assertEquals(3, sink2.openAttempts.get());
         assertThat(sinkManager.getSink("sink2"), Matchers.<Sink>sameInstance(sink2));
     }
+
+    private static class MockSinkWithBlockingClose implements Sink {
+        private volatile boolean isOpened = false;
+
+        @Override
+        public void writeTo(MessageContainer message) {
+        }
+
+        @Override
+        public void open() {
+            isOpened = true;
+        }
+
+        @Override
+        public void close() {
+            // block close for 1,000 ms
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+            isOpened = false;
+        }
+
+        @Override
+        public String recvNotice() {
+            return null;
+        }
+
+        @Override
+        public String getStat() {
+            return null;
+        }
+
+        @Override
+        public long getNumOfPendingMessages() {
+            return 0;
+        }
+
+        @Override
+        public boolean isOpened() {
+            return isOpened;
+        }
+    }
+
+    @Test
+    public void testCloseBlocking() throws Exception {
+        SinkManager sinkManager = new SinkManager();
+
+        MockSinkWithBlockingClose sink1 = new MockSinkWithBlockingClose();
+        sinkManager.initialSet(ImmutableMap.<String, Sink>of("sink1", sink1));
+        sinkManager.initialStart();
+
+        Assert.assertTrue(sink1.isOpened());
+        assertThat(sinkManager.getSink("sink1"), Matchers.<Sink>sameInstance(sink1));
+
+        MockSinkWithBlockingClose sink2 = new MockSinkWithBlockingClose();
+        // this set should return immediately
+        // because actually work is scheduled in background thread
+        long start = System.currentTimeMillis();
+        sinkManager.set(ImmutableMap.<String, Sink>of("sink2", sink2));
+        long duration = System.currentTimeMillis() - start;
+        Assert.assertTrue("duration = " + duration, duration < 50);
+
+        // sleep for a short while to let the update finish
+        Thread.sleep(200);
+        // sink1 should be replaced by sink2 in manager
+        Assert.assertNull(sinkManager.getSink("sink1"));
+        Assert.assertNotNull(sinkManager.getSink("sink2"));
+        // sink1 is NOT closed yet
+        Assert.assertTrue(sink1.isOpened());
+        // sink2 should be open
+        Assert.assertTrue(sink2.isOpened());
+
+        Thread.sleep(1000);
+        // after 1,000 ms, sink1 should be closed
+        Assert.assertFalse(sink1.isOpened());
+        // sink2 should still be open
+        Assert.assertTrue(sink2.isOpened());
+    }
 }


### PR DESCRIPTION
... can potentially block. see

https://issues.apache.org/jira/browse/KAFKA-1660
https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=53739782

However, this is still not perfect. if close blocks on waiting sender thread,
it haven't close the metrics yet. we can potentially have bad metrics.

this is the thread dump, where poller thread for persisted props got locked up
////////////////////////////////////
"pollingConfigurationSource" daemon prio=10 tid=0x0000000003547800 nid=0xfe0 in Object.wait() [0x00007f335f6c8000]
  java.lang.Thread.State: WAITING (on object monitor)
at java.lang.Object.wait(Native Method)
- waiting on <0x00000002994dae30> (a org.apache.kafka.common.utils.KafkaThread)
at java.lang.Thread.join(Thread.java:1281)
- locked <0x00000002994dae30> (a org.apache.kafka.common.utils.KafkaThread)
at java.lang.Thread.join(Thread.java:1355)
at org.apache.kafka.clients.producer.KafkaProducer.close(KafkaProducer.java:422)
at com.netflix.suro.sink.kafka.KafkaSink.close(KafkaSink.java:340)
at com.netflix.suro.sink.SinkManager.closeSink(SinkManager.java:78)
at com.netflix.suro.sink.SinkManager.set(SinkManager.java:118)
at com.netflix.chukwa.suro.SuroSinkConfigurator.buildSink(SuroSinkConfigurator.java:66)