### PR TITLE
use the default/shared computation scheduler from RxJava. there is no ne...

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.30-platform
+version=0.2.31-platform


### PR DESCRIPTION
...ed to create a dedicated thread for each metric reporter. also we may create multiple producers for each app. then we would create multiple threads for metric reporter. this was just unnecessary.