### PR TITLE
Use synchronous queue when sink does not want to drop message to deal with back pressure

### DIFF
--- a/suro-core/src/main/java/com/netflix/suro/queue/MemoryQueue4Sink.java
+++ b/suro-core/src/main/java/com/netflix/suro/queue/MemoryQueue4Sink.java
@@ -8,10 +8,17 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Memory based {@link MessageQueue4Sink}, delegating actual queueing work to {@link ArrayBlockingQueue}
+ * Memory based {@link MessageQueue4Sink}
+ * <p/>
+ * If capacity is not zero, it delegates to {@link ArrayBlockingQueue}. The queue is typically used as an asynchronous
+ * buffer between the input and sink where adding messages to the queue will fail if queue is full. Otherwise when
+ * capacity is zero, it delegates to {@link SynchronousQueue}, where the there is no buffer and input and sink are always
+ * synchronized. This is helpful when the sink does not want to deal with back-pressure but want to slow down the
+ * input without dropping messages.
  *
  * @author jbae
  */
@@ -20,14 +27,29 @@ public class MemoryQueue4Sink implements MessageQueue4Sink {
     public static final String TYPE = "memory";
 
     private final BlockingQueue<Message> queue;
+    private final int capacity;
 
     @JsonCreator
     public MemoryQueue4Sink(@JsonProperty("capacity") int capacity) {
-        this.queue = new ArrayBlockingQueue(capacity);
+        this.capacity = capacity;
+        if (capacity == 0) {
+            this.queue = new SynchronousQueue();
+        } else {
+            this.queue = new ArrayBlockingQueue(capacity);
+        }
     }
 
     @Override
     public boolean offer(Message msg) {
+        if (capacity == 0) {
+            try {
+                // for synchronous queue, this will block until the sink takes the message from the queue
+                queue.put(msg);
+            } catch (InterruptedException e) {
+                return false;
+            }
+            return true;
+        }
         return queue.offer(msg);
     }
 

--- a/suro-core/src/main/java/com/netflix/suro/queue/MemoryQueue4Sink.java
+++ b/suro-core/src/main/java/com/netflix/suro/queue/MemoryQueue4Sink.java
@@ -49,8 +49,9 @@ public class MemoryQueue4Sink implements MessageQueue4Sink {
                 return false;
             }
             return true;
+        } else {
+            return queue.offer(msg);
         }
-        return queue.offer(msg);
     }
 
     @Override

--- a/suro-core/src/test/java/com/netflix/suro/sink/TestQueuedSink.java
+++ b/suro-core/src/test/java/com/netflix/suro/sink/TestQueuedSink.java
@@ -91,6 +91,41 @@ public class TestQueuedSink {
     }
 
     @Test
+    public void synchronizedQueue() throws InterruptedException {
+        final int queueCapacity = 0;
+        final MemoryQueue4Sink queue = new MemoryQueue4Sink(queueCapacity);
+        final List<Message> sentMessageList = new LinkedList<Message>();
+
+        QueuedSink sink = new QueuedSink() {
+            @Override
+            protected void beforePolling() throws IOException {
+            }
+
+            @Override
+            protected void write(List<Message> msgList) throws IOException {
+                sentMessageList.addAll(msgList);
+            }
+
+            @Override
+            protected void innerClose() throws IOException {
+            }
+        };
+        sink.initialize(queue, 100, 1000);
+        sink.start();
+
+        int msgCount = 1000;
+        int offered = 0;
+        for (int i = 0; i < msgCount; ++i) {
+            if (queue.offer(new Message("routingKey", ("message" + i).getBytes()))) {
+                offered++;
+            }
+        }
+        assertEquals(msgCount, offered);
+        assertEquals(sentMessageList.size(), offered);
+    }
+
+
+    @Test
     public void shouldNotPauseOnShortQueue() {
         QueuedSink sink = new QueuedSink() {
             @Override


### PR DESCRIPTION
`ElasticSearchSink` uses `MessageQueue4Sink` for message handoff between the input and the sink.  Its `writeTo()` method is simply implemented as enqueuing the message to `MessageQueue4Sink`, which will drop the message if queue is full. Therefore, the queue for `ElasticSearchSink` is typically configured as a large file based queue to minimize the possibility of dropping messages. This complicates some Suro operations and monitoring as it will have local storage and hence becomes stateful.

In case that the input to `ElasticSearchSink` is `KafkaConsumer`, where there is already a file queue offered by Kafka, having another queue in the system makes things complicated and unnecessary. In this case, if sink is too busy, it should just naturally slow down the input (`KafkaConsumer`) which will cause lag in the consumer but without having to deal with back pressure.

Therefore, a synchronous queue seems to be a good fit in this case where it can block the input if sink busy, and shift the back pressure to its upstream.

With this update, user can configure the queue to be synchronous queue by specifying the capacity of the queue to be 0. 



