### PR TITLE
add a new metric for metadataNotFetched. it should be normally zero d…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.32-platform
+version=0.2.33-platform

--- a/suro-kafka-producer/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
+++ b/suro-kafka-producer/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
@@ -195,9 +195,15 @@ public class KafkaSink implements Sink {
         }
         runRecordCounterListener();
 
-        if (metadataFetchedTopicSet.contains(getRoutingKey(message))) {
+        final String routingKey = getRoutingKey(message);
+        if (metadataFetchedTopicSet.contains(routingKey)) {
             sendMessage(message);
         } else {
+            DynamicCounter.increment(
+                    MonitorConfig
+                            .builder("metadataNotFetched")
+                            .withTag(TagKey.ROUTING_KEY, routingKey)
+                            .build());
             if(!metadataWaitingQueue.offer(message)) {
                 dropMessage(getRoutingKey(message), "metadataWaitingQueueFull");
             }


### PR DESCRIPTION
…uring steady state. during startup time, it maybe non-zero when messages are queued while waiting for the initial fetch of metadata. but this metric may sustain at some value if there are messages sent to topics not created on brokers and broker has auto-topic-creation disabled.