### PR TITLE
add clientId tag to KafkaSink DynamicCounter metrics so that we can s…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.33-platform
+version=0.2.34-platform

--- a/suro-core/src/main/java/com/netflix/suro/TagKey.java
+++ b/suro-core/src/main/java/com/netflix/suro/TagKey.java
@@ -28,4 +28,5 @@ public class TagKey {
     public static final String ROUTING_KEY = "routingKey";
     public static final String REJECTED_REASON = "rejectedReason";
     public static final String DROPPED_REASON = "droppedReason";
+    public static final String CLIENT_ID = "clientId";
 }

--- a/suro-kafka-producer/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
+++ b/suro-kafka-producer/src/main/java/com/netflix/suro/sink/kafka/KafkaSink.java
@@ -203,6 +203,7 @@ public class KafkaSink implements Sink {
                     MonitorConfig
                             .builder("metadataNotFetched")
                             .withTag(TagKey.ROUTING_KEY, routingKey)
+                            .withTag(TagKey.CLIENT_ID, clientId)
                             .build());
             if(!metadataWaitingQueue.offer(message)) {
                 dropMessage(getRoutingKey(message), "metadataWaitingQueueFull");
@@ -234,6 +235,7 @@ public class KafkaSink implements Sink {
                         MonitorConfig
                                 .builder("extractPartitionKeyError")
                                 .withTag(TagKey.ROUTING_KEY, topic)
+                                .withTag(TagKey.CLIENT_ID, clientId)
                                 .build());
                 // just increment a counter and continue the send just like without key
             }
@@ -254,6 +256,7 @@ public class KafkaSink implements Sink {
                     MonitorConfig
                             .builder("attemptRecord")
                             .withTag(TagKey.ROUTING_KEY, topic)
+                            .withTag(TagKey.CLIENT_ID, clientId)
                             .build());
             producer.send(
                 new ProducerRecord(topic, part, key, message.getMessage().getPayload()),
@@ -273,6 +276,7 @@ public class KafkaSink implements Sink {
                                     MonitorConfig
                                             .builder("sentRecord")
                                             .withTag(TagKey.ROUTING_KEY, topic)
+                                            .withTag(TagKey.CLIENT_ID, clientId)
                                             .build());
                             sentRecords.incrementAndGet();
                             runRecordCounterListener();
@@ -291,6 +295,7 @@ public class KafkaSink implements Sink {
                 .builder("droppedRecord")
                 .withTag(TagKey.ROUTING_KEY, routingKey)
                 .withTag(TagKey.DROPPED_REASON, reason)
+                .withTag(TagKey.CLIENT_ID, clientId)
                 .build());
         droppedRecords.incrementAndGet();
         runRecordCounterListener();


### PR DESCRIPTION
…lice and dice on clientId. otherwise, we can't separate metrics from platform logging and suro router.